### PR TITLE
Fix multi-byte character corruption in MaterialLabel

### DIFF
--- a/MaterialSkin/NativeTextRenderer.cs
+++ b/MaterialSkin/NativeTextRenderer.cs
@@ -233,7 +233,7 @@ public sealed class NativeTextRenderer : IDisposable
         SetTextColor(_hdc, rgb);
     }
 
-    [DllImport("user32.dll")]
+    [DllImport("user32.dll", CharSet = CharSet.Auto)]
     private static extern int DrawText(IntPtr hdc, string lpchText, int cchText, ref Rect lprc, TextFormatFlags dwDTFormat);
 
     [DllImport("gdi32.dll")]


### PR DESCRIPTION
MaterialLabel#Text is corruption if assignment Japanese or other text.

before:
![before](https://user-images.githubusercontent.com/20186429/93203780-edc95480-f78f-11ea-883c-16dd75fdb5d4.png)

after:
![after](https://user-images.githubusercontent.com/20186429/93203797-f6218f80-f78f-11ea-9f80-5b5832563416.png)

